### PR TITLE
Use `log` crate for logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ keywords   = ["ccid", "ecdsa", "rsa", "piv", "yubikey"]
 
 [dependencies]
 libc = "0.2"
+log = "0.4"
 zeroize = "1"

--- a/src/apdu.rs
+++ b/src/apdu.rs
@@ -1,5 +1,6 @@
 //! Application Protocol Data Unit (APDU)
 
+use std::fmt::{self, Debug};
 use zeroize::Zeroize;
 
 /// Application Protocol Data Unit (APDU).
@@ -28,16 +29,25 @@ pub struct APDU {
 }
 
 impl APDU {
-    /// Get a const pointer to this APDU
-    // TODO(tarcieri): eliminate pointers and use all safe references
-    pub(crate) fn as_ptr(&self) -> *const APDU {
-        self
-    }
-
     /// Get a mut pointer to this APDU
     // TODO(tarcieri): eliminate pointers and use all safe references
     pub(crate) fn as_mut_ptr(&mut self) -> *mut APDU {
         self
+    }
+}
+
+impl Debug for APDU {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "APDU {{ cla: {}, ins: {}, p1: {}, p2: {}, lc: {}, data: {:?} }}",
+            self.cla,
+            self.ins,
+            self.p1,
+            self.p2,
+            self.lc,
+            &self.data[..]
+        )
     }
 }
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -36,6 +36,12 @@
 
 pub const szLOG_SOURCE: &str = "yubikey-piv.rs";
 
+pub const ADMIN_FLAGS_1_PUK_BLOCKED: u8 = 0x01;
+pub const ADMIN_FLAGS_1_PROTECTED_MGM: u8 = 0x02;
+
+pub const CB_ADMIN_TIMESTAMP: usize = 0x04;
+pub const CB_ADMIN_SALT: usize = 16;
+
 pub const CB_OBJ_MAX: usize = 3063;
 
 pub const CB_OBJ_TAG_MIN: usize = 2; // 1 byte tag + 1 byte len
@@ -64,6 +70,10 @@ pub const DEVTYPE_YK: u32 = 0x594B_0000; //"YK"
 pub const DEVTYPE_NEOr3: u32 = (DEVTYPE_NEO | 0x0000_7233); //"r3"
 pub const DEVTYPE_YK4: u32 = (DEVTYPE_YK | 0x0000_0034); // "4"
 pub const DEVYTPE_YK5: u32 = (DEVTYPE_YK | 0x0000_0035); // "5"
+
+pub const ITER_MGM_PBKDF2: usize = 10000;
+
+pub const PROTECTED_FLAGS_1_PUK_NOBLOCK: u8 = 0x01;
 
 // sw is status words, see NIST special publication 800-73-4, section 5.6
 


### PR DESCRIPTION
Switches all of the previous `state->verbose`-gated `eprintln!` calls to use macros from the `log` crate, trying to map them onto the previous verbosity levels, more or less following this mapping:

0. off
1. error/info/warn (depending on context)
2. trace

This additionally includes a bunch of logic/branch reformatting (and occasional missed constants), since getting rid of all the gating on verbose provided ample opportunities to clean up the code. Hopefully I didn't break too much in the process!