### PR TITLE
Replace PKCS5_PBKDF2_HMAC_SHA1 with crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ keywords   = ["ccid", "ecdsa", "rsa", "piv", "yubikey"]
 
 [dependencies]
 getrandom = "0.1"
+hmac = "0.7"
 libc = "0.2"
 log = "0.4"
+pbkdf2 = "0.3"
+sha-1 = "0.8"
 zeroize = "1"

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -60,15 +60,6 @@ extern "C" {
     );
     fn DES_is_weak_key(key: *mut [u8; 8]) -> i32;
     fn DES_set_key_unchecked(key: *mut [u8; 8], schedule: *mut DesSubKey);
-    fn PKCS5_PBKDF2_HMAC_SHA1(
-        pass: *const u8,
-        passlen: i32,
-        salt: *const u8,
-        saltlen: i32,
-        iter: i32,
-        keylen: i32,
-        out: *mut u8,
-    ) -> i32;
 }
 
 /// DES-related errors
@@ -242,29 +233,6 @@ pub enum Pkcs5ErrorKind {
 
     /// General error
     GeneralError = -1,
-}
-
-/// Decrypt a PKCS#5 key
-pub unsafe fn pkcs5_pbkdf2_sha1(
-    password: *const u8,
-    cb_password: usize,
-    salt: *const u8,
-    cb_salt: usize,
-    iterations: usize,
-    key: *const u8,
-    cb_key: usize,
-) -> Pkcs5ErrorKind {
-    PKCS5_PBKDF2_HMAC_SHA1(
-        password,
-        cb_password as (i32),
-        salt,
-        cb_salt as (i32),
-        iterations as (i32),
-        cb_key as (i32),
-        key as (*mut u8),
-    );
-
-    Pkcs5ErrorKind::Ok
 }
 
 /// Strip whitespace


### PR DESCRIPTION
Also tidies up ykpiv_util_get_derived_mgm (which was the only consumer of the function) and fixes some porting bugs.