### PR TITLE
Add `untested` Cargo feature for untested functionality

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,14 @@ jobs:
           command: test
           args: --release
 
+      - name: Run cargo build --all-features
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -D warnings
+        with:
+          command: build
+          args: --all-features
+
   test:
     name: Test Suite
     strategy:
@@ -87,6 +95,14 @@ jobs:
         with:
           command: test
           args: --release
+
+      - name: Run cargo build --all-features
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -D warnings
+        with:
+          command: build
+          args: --all-features
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ application providing general-purpose public-key signing and encryption
 with hardware-backed private keys for RSA (2048/1024) and ECC (P-256/P-384)
 algorithms (e.g, PKCS#1v1.5, ECDSA)
 """
-
 authors    = ["Tony Arcieri <bascule@gmail.com>", "Yubico AB"]
 edition    = "2018"
 license    = "BSD-2-Clause"
@@ -16,16 +15,25 @@ readme     = "README.md"
 categories = ["api-bindings", "cryptography", "hardware-support"]
 keywords   = ["ccid", "ecdsa", "rsa", "piv", "yubikey"]
 
+[badges]
+maintenance = { status = "experimental" }
+
 [dependencies]
 des = "0.3"
 getrandom = "0.1"
-hmac = "0.7"
+hmac = { version = "0.7", optional = true }
 log = "0.4"
-pbkdf2 = "0.3"
+pbkdf2 = { version = "0.3", optional = true }
 pcsc = "2"
-sha-1 = "0.8"
-subtle = "2"
+sha-1 = { version = "0.8", optional = true }
+subtle = { version = "2", optional = true }
 zeroize = "1"
 
 [dev-dependencies]
 env_logger = "0.7"
+
+[features]
+untested = ["hmac", "pbkdf2", "sha-1", "subtle"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ Legend:
 | 🚧 | Testing and validation in progress |
 | ⚠️ | Untested support                   |
 
-NOTE: Commands marked ⚠️ have not been properly tested and may contain bugs or
-not work at all.
+NOTE: Commands marked ⚠️ are disabled by default as they have have not been properly tested and may contain bugs or
+not work at all. USE AT YOUR OWN RISK!
+
+Enable the `untested` feature in your `Cargo.toml` to enable features marked ⚠️
+above.
 
 ## Testing
 

--- a/src/apdu.rs
+++ b/src/apdu.rs
@@ -71,6 +71,7 @@ impl APDU {
     }
 
     /// Set this APDU's class
+    #[cfg(feature = "untested")]
     pub fn cla(&mut self, value: u8) -> &mut Self {
         self.cla = value;
         self
@@ -83,6 +84,7 @@ impl APDU {
     }
 
     /// Set both parameters for this APDU
+    #[cfg(feature = "untested")]
     pub fn params(&mut self, p1: u8, p2: u8) -> &mut Self {
         self.p1 = p1;
         self.p2 = p2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! code from upstream [yubico-piv-tool] has been translated into Rust
 //! presenting a safe interface, much of it is still untested.
 //!
-//! Please see the project's README.md for a complete status.
+//! Please see the [project's README.md for a complete status][status].
 //!
 //! ## History
 //!
@@ -83,6 +83,7 @@
 //! [YubiKey NEO]: https://support.yubico.com/support/solutions/articles/15000006494-yubikey-neo
 //! [YubiKey 4]: https://support.yubico.com/support/solutions/articles/15000006486-yubikey-4
 //! [YubiKey 5]: https://www.yubico.com/products/yubikey-5-overview/
+//! [status]: https://github.com/tarcieri/yubikey-piv.rs#status
 //! [yubico-piv-tool]: https://github.com/Yubico/yubico-piv-tool/
 //! [Corrode]: https://github.com/jameysharp/corrode
 //! [piv-tool-guide]: https://www.yubico.com/wp-content/uploads/2016/05/Yubico_PIV_Tool_Command_Line_Guide_en.pdf
@@ -134,24 +135,37 @@
 )]
 
 mod apdu;
+#[cfg(feature = "untested")]
 pub mod cccid;
+#[cfg(feature = "untested")]
 pub mod certificate;
+#[cfg(feature = "untested")]
 pub mod chuid;
+#[cfg(feature = "untested")]
 pub mod config;
 pub mod consts;
+#[cfg(feature = "untested")]
 pub mod container;
 pub mod error;
+#[cfg(feature = "untested")]
 pub mod key;
+#[cfg(feature = "untested")]
 mod metadata;
+#[cfg(feature = "untested")]
 pub mod mgm;
+#[cfg(feature = "untested")]
 pub mod msroots;
 mod response;
+#[cfg(feature = "untested")]
 mod serialization;
+#[cfg(feature = "untested")]
 pub mod settings;
 mod transaction;
 pub mod yubikey;
 
-pub use self::{key::Key, mgm::MgmKey, yubikey::YubiKey};
+#[cfg(feature = "untested")]
+pub use self::{key::Key, mgm::MgmKey};
+pub use yubikey::YubiKey;
 
 /// Algorithm identifiers
 // TODO(tarcieri): make this an enum

--- a/src/response.rs
+++ b/src/response.rs
@@ -64,6 +64,7 @@ impl Response {
     }
 
     /// Create a new response from the given status words and buffer
+    #[cfg(feature = "untested")]
     pub fn new(status_words: StatusWords, buffer: Buffer) -> Response {
         Response {
             status_words,
@@ -77,6 +78,7 @@ impl Response {
     }
 
     /// Get the raw [`StatusWords`] code for this response.
+    #[cfg(feature = "untested")]
     pub fn code(&self) -> u32 {
         self.status_words.code()
     }
@@ -92,6 +94,7 @@ impl Response {
     }
 
     /// Consume this response, returning its buffer
+    #[cfg(feature = "untested")]
     pub fn into_buffer(self) -> Buffer {
         self.buffer
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,17 +1,17 @@
 //! YubiKey PC/SC transactions
 
+use crate::{apdu::APDU, consts::*, error::Error, yubikey::*, Buffer};
+#[cfg(feature = "untested")]
 use crate::{
-    apdu::APDU,
-    consts::*,
-    error::Error,
     mgm::MgmKey,
     response::{Response, StatusWords},
     serialization::*,
-    yubikey::*,
-    Buffer, ObjectId,
+    ObjectId,
 };
 use log::{error, trace};
-use std::{convert::TryInto, ptr};
+use std::convert::TryInto;
+#[cfg(feature = "untested")]
+use std::ptr;
 use zeroize::Zeroizing;
 
 /// Exclusive transaction with the YubiKey's PC/SC card.
@@ -164,6 +164,7 @@ impl<'tx> Transaction<'tx> {
     }
 
     /// Verify device PIN.
+    #[cfg(feature = "untested")]
     pub fn verify_pin(&self, pin: &[u8]) -> Result<(), Error> {
         // TODO(tarcieri): allow unpadded (with `0xFF`) PIN shorter than CB_PIN_MAX?
         if pin.len() != CB_PIN_MAX {
@@ -184,6 +185,7 @@ impl<'tx> Transaction<'tx> {
     }
 
     /// Change the PIN
+    #[cfg(feature = "untested")]
     pub fn change_pin(&self, action: i32, current_pin: &[u8], new_pin: &[u8]) -> Result<(), Error> {
         let mut templ = [0, YKPIV_INS_CHANGE_REFERENCE, 0, 0x80];
         let mut indata = Zeroizing::new([0u8; 16]);
@@ -243,6 +245,7 @@ impl<'tx> Transaction<'tx> {
     }
 
     /// Set the management key (MGM).
+    #[cfg(feature = "untested")]
     pub fn set_mgm_key(&self, new_key: &MgmKey, touch: Option<u8>) -> Result<(), Error> {
         let p2 = match touch.unwrap_or_default() {
             0 => 0xff,
@@ -276,6 +279,7 @@ impl<'tx> Transaction<'tx> {
     /// This is the common backend for all public key encryption and signing
     /// operations.
     // TODO(tarcieri): refactor this to be less gross/coupled.
+    #[cfg(feature = "untested")]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn authenticated_command(
         &self,
@@ -392,6 +396,7 @@ impl<'tx> Transaction<'tx> {
     /// messages into smaller APDU-sized messages (using the provided APDU
     /// template to construct them), and then sending those via
     /// [`Transaction::transmit`].
+    #[cfg(feature = "untested")]
     pub fn transfer_data(
         &self,
         templ: &[u8],
@@ -475,6 +480,7 @@ impl<'tx> Transaction<'tx> {
     }
 
     /// Fetch an object
+    #[cfg(feature = "untested")]
     pub fn fetch_object(&self, object_id: ObjectId) -> Result<Buffer, Error> {
         let mut indata = [0u8; 5];
         let templ = [0, YKPIV_INS_GET_DATA, 0x3f, 0xff];
@@ -518,6 +524,7 @@ impl<'tx> Transaction<'tx> {
     }
 
     /// Save an object
+    #[cfg(feature = "untested")]
     pub fn save_object(&self, object_id: ObjectId, indata: &[u8]) -> Result<(), Error> {
         let templ = [0, YKPIV_INS_PUT_DATA, 0x3f, 0xff];
 


### PR DESCRIPTION
This adds an `untested` feature to any functions which have not yet been tested live against a YubiKey device (which is presently pretty much everything).

This sets a clear expectation of what is presently supported, and additionally documents the status in the README (and a series of GitHub issues).

Adds a `cargo build --all-features` to GitHub Actions' `test` step in order to make sure that `untested` functionality still compiles.