### PR TITLE
v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] (2019-11-25)
+### Added
+- `untested` Cargo feature to mark untested functionality ([#30])
+- Initial connect test and docs ([#19])
+- Clean up APDU construction with builder API ([#15])
+
+### Changed
+- Rewrite translated code to use the `pcsc` crate ([#17])
+- Rename ErrorKind to Error ([#13])
+- Use `des` crate for 3DES operations ([#10])
+- Replace `PKCS5_PBKDF2_HMAC_SHA1` with `pbkdf2` et al crates ([#9])
+- Replace `RAND_bytes` with `getrandom` crate ([#8])
+- Use `log` crate for logging ([#7])
+- Replace `ErrorKind::Ok` with `Result` ([#6])
+
+[0.0.2]: https://github.com/tarcieri/yubikey-piv.rs/pull/31
+[#30]: https://github.com/tarcieri/yubikey-piv.rs/pull/30
+[#19]: https://github.com/tarcieri/yubikey-piv.rs/pull/19
+[#17]: https://github.com/tarcieri/yubikey-piv.rs/pull/17
+[#15]: https://github.com/tarcieri/yubikey-piv.rs/pull/15
+[#13]: https://github.com/tarcieri/yubikey-piv.rs/pull/13
+[#10]: https://github.com/tarcieri/yubikey-piv.rs/pull/10
+[#9]: https://github.com/tarcieri/yubikey-piv.rs/pull/9
+[#8]: https://github.com/tarcieri/yubikey-piv.rs/pull/8
+[#7]: https://github.com/tarcieri/yubikey-piv.rs/pull/7
+[#6]: https://github.com/tarcieri/yubikey-piv.rs/pull/6
+
 ## 0.0.1 (2019-11-18)
 - It typechecks, ship it!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "yubikey-piv"
-version = "0.0.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.0.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust host-side driver for the YubiKey Personal Identity Verification (PIV)
 application providing general-purpose public-key signing and encryption
@@ -21,19 +21,19 @@ maintenance = { status = "experimental" }
 [dependencies]
 des = "0.3"
 getrandom = "0.1"
-hmac = { version = "0.7", optional = true }
+hmac = "0.7"
 log = "0.4"
-pbkdf2 = { version = "0.3", optional = true }
+pbkdf2 = "0.3"
 pcsc = "2"
-sha-1 = { version = "0.8", optional = true }
-subtle = { version = "2", optional = true }
+sha-1 = "0.8"
+subtle = "2"
 zeroize = "1"
 
 [dev-dependencies]
 env_logger = "0.7"
 
 [features]
-untested = ["hmac", "pbkdf2", "sha-1", "subtle"]
+untested = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tarcieri/yubikey-piv.rs/develop/img/logo.png",
-    html_root_url = "https://docs.rs/yubikey-piv/0.0.1"
+    html_root_url = "https://docs.rs/yubikey-piv/0.0.2"
 )]
 #![warn(
     missing_docs,


### PR DESCRIPTION
Publishing an early v0.0.2 so the new README.md with more status info shows up on https://crates.io and also to show the current state of the library on https://docs.rs

### Added
- `untested` Cargo feature to mark untested functionality ([#30])
- Initial connect test and docs ([#19])
- Clean up APDU construction with builder API ([#15])

### Changed
- Rewrite translated code to use the `pcsc` crate ([#17])
- Rename ErrorKind to Error ([#13])
- Use `des` crate for 3DES operations ([#10])
- Replace `PKCS5_PBKDF2_HMAC_SHA1` with `pbkdf2` et al crates ([#9])
- Replace `RAND_bytes` with `getrandom` crate ([#8])
- Use `log` crate for logging ([#7])
- Replace `ErrorKind::Ok` with `Result` ([#6])

[0.0.2]: https://github.com/tarcieri/yubikey-piv.rs/pull/31
[#30]: https://github.com/tarcieri/yubikey-piv.rs/pull/30
[#19]: https://github.com/tarcieri/yubikey-piv.rs/pull/19
[#17]: https://github.com/tarcieri/yubikey-piv.rs/pull/17
[#15]: https://github.com/tarcieri/yubikey-piv.rs/pull/15
[#13]: https://github.com/tarcieri/yubikey-piv.rs/pull/13
[#10]: https://github.com/tarcieri/yubikey-piv.rs/pull/10
[#9]: https://github.com/tarcieri/yubikey-piv.rs/pull/9
[#8]: https://github.com/tarcieri/yubikey-piv.rs/pull/8
[#7]: https://github.com/tarcieri/yubikey-piv.rs/pull/7
[#6]: https://github.com/tarcieri/yubikey-piv.rs/pull/6