### PR TITLE
`Ins` (APDU instruction codes) enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,16 @@ To trace every message sent to/from the card i.e. the raw
 Application Protocol Data Unit (APDU) messages, use the `trace` log level:
 
 ```
+running 1 test
 [INFO  yubikey_piv::yubikey] trying to connect to reader 'Yubico YubiKey OTP+FIDO+CCID'
 [INFO  yubikey_piv::yubikey] connected to 'Yubico YubiKey OTP+FIDO+CCID' successfully
-[TRACE yubikey_piv::apdu] >>> APDU { cla: 0, ins: 164, p1: 4, p2: 0, lc: 5, data: [160, 0, 0, 3, 8] }
+[TRACE yubikey_piv::apdu] >>> APDU { cla: 0, ins: SelectApplication, p1: 4, p2: 0, data: [160, 0, 0, 3, 8] }
 [TRACE yubikey_piv::transaction] >>> [0, 164, 4, 0, 5, 160, 0, 0, 3, 8]
 [TRACE yubikey_piv::apdu] <<< Response { status_words: Success, data: [97, 17, 79, 6, 0, 0, 16, 0, 1, 0, 121, 7, 79, 5, 160, 0, 0, 3, 8] }
-[TRACE yubikey_piv::apdu] >>> APDU { cla: 0, ins: 253, p1: 0, p2: 0, lc: 0, data: [] }
+[TRACE yubikey_piv::apdu] >>> APDU { cla: 0, ins: GetVersion, p1: 0, p2: 0, data: [] }
 [TRACE yubikey_piv::transaction] >>> [0, 253, 0, 0, 0]
 [TRACE yubikey_piv::apdu] <<< Response { status_words: Success, data: [5, 1, 2] }
-[TRACE yubikey_piv::apdu] >>> APDU { cla: 0, ins: 248, p1: 0, p2: 0, lc: 0, data: [] }
+[TRACE yubikey_piv::apdu] >>> APDU { cla: 0, ins: GetSerial, p1: 0, p2: 0, data: [] }
 [TRACE yubikey_piv::transaction] >>> [0, 248, 0, 0, 0]
 [TRACE yubikey_piv::apdu] <<< Response { status_words: Success, data: [0, 115, 0, 178] }
 test connect ... ok

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -136,26 +136,6 @@ pub const YKPIV_CCCID_SIZE: usize = 14;
 pub const YKPIV_CERTINFO_UNCOMPRESSED: u8 = 0;
 pub const YKPIV_CERTINFO_GZIP: u8 = 1;
 
-pub const YKPIV_INS_VERIFY: u8 = 0x20;
-pub const YKPIV_INS_CHANGE_REFERENCE: u8 = 0x24;
-pub const YKPIV_INS_RESET_RETRY: u8 = 0x2c;
-pub const YKPIV_INS_GENERATE_ASYMMETRIC: u8 = 0x47;
-pub const YKPIV_INS_AUTHENTICATE: u8 = 0x87;
-pub const YKPIV_INS_GET_DATA: u8 = 0xcb;
-pub const YKPIV_INS_PUT_DATA: u8 = 0xdb;
-pub const YKPIV_INS_SELECT_APPLICATION: u8 = 0xa4;
-pub const YKPIV_INS_GET_RESPONSE_APDU: u8 = 0xc0;
-
-// Yubico vendor specific instructions
-// <https://developers.yubico.com/PIV/Introduction/Yubico_extensions.html>
-pub const YKPIV_INS_SET_MGMKEY: u8 = 0xff;
-pub const YKPIV_INS_IMPORT_KEY: u8 = 0xfe;
-pub const YKPIV_INS_GET_VERSION: u8 = 0xfd;
-pub const YKPIV_INS_RESET: u8 = 0xfb;
-pub const YKPIV_INS_SET_PIN_RETRIES: u8 = 0xfa;
-pub const YKPIV_INS_ATTEST: u8 = 0xf9;
-pub const YKPIV_INS_GET_SERIAL: u8 = 0xf8;
-
 pub const YKPIV_KEY_AUTHENTICATION: u8 = 0x9a;
 pub const YKPIV_KEY_CARDMGM: u8 = 0x9b;
 pub const YKPIV_KEY_SIGNATURE: u8 = 0x9c;

--- a/src/key.rs
+++ b/src/key.rs
@@ -38,7 +38,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    apdu::StatusWords,
+    apdu::{Ins, StatusWords},
     certificate::{self, Certificate},
     consts::*,
     error::Error,
@@ -199,7 +199,7 @@ pub fn generate(
     touch_policy: u8,
 ) -> Result<GeneratedKey, Error> {
     let mut in_data = [0u8; 11];
-    let mut templ = [0, YKPIV_INS_GENERATE_ASYMMETRIC, 0, 0];
+    let mut templ = [0, Ins::GenerateAsymmetric.code(), 0, 0];
     let setting_roca: settings::BoolValue;
 
     if yubikey.device_model() == DEVTYPE_YK4


### PR DESCRIPTION
Converts a bag of constant values (`YKPIV_INS_*`) into an enum representing APDU instruction codes (a.k.a. `ins`).

Among other things, this makes the `Debug` output for `APDU` more human meaningful, since it can print a text label for the instruction rather than a code number, which is helpful in trace debugging.